### PR TITLE
Add ChartScout link to crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ A curated list of financial tools
 * https://coinmarketcap.com/
 * https://pools.fyi
 * https://github.com/ccxt/ccxt
+* https://chartscout.io 
 
 ## Software Tools
 


### PR DESCRIPTION
Add ChartScout link to crypto. Scan 1000+ crypto pairs for patterns like rising wedges & triangles in real-time. Get Discord/email alerts, no API keys needed. Free tier available.