### PR TITLE
Add Congressional Stock Brain to AI Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A curated list of financial tools
 * https://quantalytics.ai/
 * https://github.com/stefan-jansen/machine-learning-for-trading
 * https://github.com/achillesrasquinha/bulbea
+* https://congressionalstockbrain.com
 * https://ledge.bedrock-ai.com/
 
 


### PR DESCRIPTION
Adding Congressional Stock Brain (https://congressionalstockbrain.com) to the AI Tools section.

Congressional Stock Brain is a free AI-powered fintech tool that ingests U.S. STOCK Act disclosures (publicly filed lawmaker trades) and converts them into AI-scored trade signals for retail investors. It scores each disclosure by committee relevance, timing vs. legislative activity, trade size, and disclosure delay. Free to use, no login required.