### PR TITLE
Add Helium to AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A curated list of financial tools
 * https://github.com/achillesrasquinha/bulbea
 * https://congressionalstockbrain.com
 * https://ledge.bedrock-ai.com/
+* https://heliumtrades.com/mcp-page/
 
 
 ## Data


### PR DESCRIPTION
## Summary

Adds [Helium](https://heliumtrades.com/mcp-page/) to the **AI Tools** section of the curated list.

## About Helium

- **Website:** https://heliumtrades.com/mcp-page/
- **GitHub (MCP server):** https://github.com/connerlambden/helium-mcp
- **Description:** Live market data with AI bull/bear analysis, ML options pricing, top trading strategies, and news bias scoring across 5,000+ sources. Ships as an MCP server and REST API, with 50 free queries and no authentication required.

## Placement

Listed under **AI Tools** (alongside Toggle, Quantalytics, etc.) because the product centers on AI-driven market views, ML pricing, and automated news bias scoring. It also exposes market data, so it could fit **Data** if you prefer to categorize it there instead.

## Change

- One new bullet in `README.md` following the existing URL-only list format.

Made with [Cursor](https://cursor.com)